### PR TITLE
Don't install handlers

### DIFF
--- a/core/Test/Tasty/CmdLine.hs
+++ b/core/Test/Tasty/CmdLine.hs
@@ -19,7 +19,8 @@ import System.IO
 -- GHC 7.4 lacks mkWeakThreadId (see #181), and this is not important
 -- enough to look for an alternative implementation, so we just disable it
 -- there.
-#define INSTALL_HANDLERS defined UNIX && MIN_VERSION_base(4,6,0)
+-- #define INSTALL_HANDLERS defined UNIX && MIN_VERSION_base(4,6,0)
+#define INSTALL_HANDLERS false
 
 #if INSTALL_HANDLERS
 import Control.Concurrent (mkWeakThreadId, myThreadId)


### PR DESCRIPTION
This causes problems with sparkle tests, because sparkle/JVM does weird things with signals. I don't see any negative effects from not installing these handlers.

See https://github.com/LeapYear/leapyear/blob/master/docs/sparkle-signals.md